### PR TITLE
Initialize ir_cache to invalid values

### DIFF
--- a/lib/xwiimote.h
+++ b/lib/xwiimote.h
@@ -811,7 +811,7 @@ struct xwii_event {
  */
 static inline bool xwii_event_ir_is_valid(const struct xwii_event_abs *abs)
 {
-	return abs->x != 1023 || abs->y != 1023;
+	return abs->x != 1023 && abs->y != 1023;
 }
 
 /** @} */


### PR DESCRIPTION
Ensure that IR data makes sense in `xwii_event_ir_is_valid`.